### PR TITLE
Fix Cat.sleep()

### DIFF
--- a/pyCatSim/api/cat.py
+++ b/pyCatSim/api/cat.py
@@ -329,7 +329,7 @@ class Cat:
         return {"hunger_level": self.hunger_level, "mood": self.mood}
 
 
-    def sleep(self, duration=0):
+    def sleep(self, duration):
         """
         Simulates the cat getting some sleep.
 
@@ -340,7 +340,7 @@ class Cat:
 
         Parameters
         ----------
-        duration : int or float, optional
+        duration : int or float
             Number of hours the cat sleeps. Must be an integer or float. The default is 0.
 
         Raises

--- a/pyCatSim/tests/test_api_Cat.py
+++ b/pyCatSim/tests/test_api_Cat.py
@@ -162,19 +162,21 @@ class TestcatCatSleep:
                              [
                                  (0),
                                  (1),
-                                 (4.4),
+                                 (14.4),
                                  pytest.param("kitty", marks=pytest.mark.xfail),
                                  pytest.param(-1, marks=pytest.mark.xfail),
                                  pytest.param(17, marks=pytest.mark.xfail)
                                  ]
                              )
     def test_sleep_t0(self, duration):
-        cat = Cat(name="Boots", color="tabby")
+        cat = Cat(name="Boots", color="tabby", energy=0)
 
         cat.sleep(duration)
         
         if duration < 3:
             assert cat.energy == 0
+	if ((duration >= 12) and (duration < 15)):
+	    assert cat.energy == 4
 
 
 class TestcatCatFact:


### PR DESCRIPTION
Additional patches to Issue #10 

pyCatSim/pyCatSim/api/cat.py
- 'duration' argument in Cat.sleep() changed from an optional argument (default=0) to a required argument

pyCatSim/pyCatSim/tests/test_api_Cat.py
- added assertion for test parameter where increase in cat.energy is greater than 0 in TestcatCatSleep.test_sleep_t0()