### PR TITLE
Fix Cat.sleep() and improve unit test

### DIFF
--- a/pyCatSim/api/cat.py
+++ b/pyCatSim/api/cat.py
@@ -331,7 +331,7 @@ class Cat:
         return {"hunger_level": self.hunger_level, "mood": self.mood}
 
 
-    def sleep(self, duration=0):
+    def sleep(self, duration):
         """
         Simulates the cat getting some sleep.
 
@@ -342,7 +342,7 @@ class Cat:
 
         Parameters
         ----------
-        duration : int or float, optional
+        duration : int or float
             Number of hours the cat sleeps. Must be an integer or float. The default is 0.
 
         Raises
@@ -355,7 +355,7 @@ class Cat:
         Examples
         --------
         
-        ..jupyter-execute::
+        .. jupyter-execute::
             
             import pyCatSim as cats
             nutmeg = cats.Cat(name='Nutmeg', age = 3, color = 'tortoiseshell')

--- a/pyCatSim/tests/test_api_Cat.py
+++ b/pyCatSim/tests/test_api_Cat.py
@@ -175,6 +175,7 @@ class TestcatCatSleep:
         
         if duration < 3:
             assert cat.energy == 0
+	
 		if (duration >= 12) and (duration < 15):
 			assert cat.energy == 4
 

--- a/pyCatSim/tests/test_api_Cat.py
+++ b/pyCatSim/tests/test_api_Cat.py
@@ -162,7 +162,7 @@ class TestcatCatSleep:
                              [
                                  (0),
                                  (1),
-                                 (4.4),
+                                 (14.4),
                                  pytest.param("kitty", marks=pytest.mark.xfail),
                                  pytest.param(-1, marks=pytest.mark.xfail),
                                  pytest.param(17, marks=pytest.mark.xfail)
@@ -175,7 +175,8 @@ class TestcatCatSleep:
         
         if duration < 3:
             assert cat.energy == 0
-
+		if (duration >= 12) and (duration < 15):
+			assert cat.energy == 4
 
 class TestcatCatFact:
     ''' Test for the give_fact function'''


### PR DESCRIPTION
Added improvements to Cat.sleep() and associated unit tests:

1. 'duration' argument in Cat.sleep() is now required, not optional (also fixed in docstrings)
2. Fixed missing space in jupyter-execute example that prevents it from building correctly
3.  Added assertion in parameterized 'duration' unit test to make sure the increase to Cat.energy when calling Cat.sleep() is additive